### PR TITLE
Implement sort into api call and UI.

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -2,7 +2,7 @@ import './App.css';
 import loading from '../../images/loading.png';
 import NewsFeed from '../NewsFeed/NewsFeed.js';
 import React, { Component } from 'react';
-import { NavLink, Route, Router } from 'react-router-dom';
+import { NavLink, Route} from 'react-router-dom';
 import {wordAPI} from '../../api-requests.js';
 
 class App extends Component {
@@ -11,13 +11,15 @@ class App extends Component {
     this.state = {
       numPhrases: 1,
       isError: false,
+      isLoading: true,
       loadingOverlayState: 'shown',
+      mightSortBy: 'relevance',
       minimumWords: 1,
       maximumWords: 1,
       pageMax: 1,
-      query: '...',
+      query: null,
       showPreferences: false,
-      sortBy: 'Recent'
+      sortBy: 'relevance'
     }
   }
 
@@ -56,15 +58,15 @@ class App extends Component {
     wordAPI.getPhrase(this.state.minimumWords, this.state.maximumWords)
     .then( words => {
       if (words === 'error') {
-        return this.setState( {isError: true} )
+        return this.setState( {isError: true, isLoading: false} )
       }
-      this.setState( {query: words.join(' '), currentPage: 1} )
+      this.setState( {query: words.join(' '), currentPage: 1, isLoading: false} )
     })
-    .catch( () => this.setState( {isError: true} ))
+    .catch( () => this.setState( {isError: true, isLoading: false} ))
   }
 
-  sortArticles = () => {
-    console.log('PlaceHolder. Sort By:', this.state.sortBy);
+  setSort = () => {
+    this.setState({sort: this.state.mightSortBy});
   }
 
   Header = () => {
@@ -101,8 +103,9 @@ class App extends Component {
         isError={this.state.isError}
         query={this.state.query}
         setAppState={this.setAppState}
+        sort={this.state.sort}
       />
-    )
+    );
   }
 
   OffsetPage = (props) => {
@@ -112,6 +115,7 @@ class App extends Component {
         isError={this.state.isError}
         query={this.state.query}
         setAppState={this.setAppState}
+        sort={this.state.sort}
       />
     )
   }
@@ -143,7 +147,7 @@ class App extends Component {
   }
 
   render() {
-    if (this.query === '...') {
+    if (this.state.isLoading) {
       return (
         <div className='shown'>
           <img
@@ -155,12 +159,12 @@ class App extends Component {
       )
     }
 
-    let btnData = {text:'Sort By', onClick: this.sortArticles};
+    let btnData = {text:'Sort By', onClick: this.setSort};
     return (
       <>
         <this.Header />
         <main>
-          {this.createSelect('sortBy', null, btnData, 'Recent', 'Relevance', 'Oldest')}
+          {this.createSelect('mightSortBy', null, btnData, 'relevance', 'newest', 'oldest')}
           <this.PageSelect pageMax={this.state.pageMax}/>
           <div className={this.state.loadingOverlayState}>
             <img

--- a/src/Components/NewsFeed/NewsFeed.js
+++ b/src/Components/NewsFeed/NewsFeed.js
@@ -15,35 +15,37 @@ class NewsFeed extends Component {
 
   componentDidMount() {
     if (!this.props.isError) {
-      this.getArticles(this.props.query, this.props.currentPage)
+      this.getArticles(this.props.query, this.props.currentPage, this.props.sort)
     }
   }
 
   componentWillReceiveProps(next) {
     let queryChange = next.query !== this.props.query;
     let pageChange = next.currentPage !== this.props.currentPage;
+    let sortChange = next.sort !== this.props.sort;
     let valid = !this.props.isError;
-    if ( valid && (queryChange || pageChange) ) {
-      this.getArticles(next.query, next.currentPage);
+    if ( valid && (queryChange || pageChange || sortChange) ) {
+      this.getArticles(next.query, next.currentPage, next.sort);
     }
   }
 
-  getArticles(query, page) {
+  getArticles(query, page, sort) {
     this.props.setAppState( {loadingOverlayState: 'shown'} )
-    timesAPI.getArticles(query, page - 1)
+    timesAPI.getArticles(query, page - 1, sort)
     .then( data => {
       if (data === 'error') {
-        return this.setState( {isError: true, loadingOverlayState: 'hidden'} )
+        return this.setState( {isError: true, isLoading: false, loadingOverlayState: 'hidden'} )
       }
       this.setState( {articles: data.response.docs} )
       this.props.setAppState( {
         isError: false,
+        isLoading: false,
         loadingOverlayState: 'hidden',
         pageMax: Math.min( Math.ceil(data.response.meta.hits / 10), 100)
       } )
     })
     .catch( () => {
-      this.props.setAppState( {isError: true, loadingOverlayState: 'hidden'} )
+      this.props.setAppState( {isError: true, isLoading: false, loadingOverlayState: 'hidden'} )
     })
   }
 

--- a/src/api-requests.js
+++ b/src/api-requests.js
@@ -84,8 +84,8 @@ export const timesAPI = {
 
   key: '&api-key=L5x1jxc7BGK5GdsesCTan33ncRlP52P6',
 
-  getArticles(query, page = 0) {
-    return fetch(timesAPI.url + `q=${query}` + timesAPI.key + `&page=${page}`)
+  getArticles(query, page = 0, sort = 'relevance') {
+    return fetch(timesAPI.url + `q=${query}` + timesAPI.key + `&page=${page}` + `&sort=${sort}`)
     .then( response => {
       if (response.ok) {
         return response.json();


### PR DESCRIPTION
## Description

Hooked up the sort by button with the actual sorting functionality. It was just a matter of leveraging the NYT's API sort and making sure the page would update when it changed.


## How Has This Been Tested?

- [ ] Test Suite
- [x] In Browser
- [ ] In console
- [ ] It hasn't
- [x] Tests are broken / missing and need to be fixed

## Relevant Tickets

closes #9 
closes #10 